### PR TITLE
Build by Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,12 @@ rustflags = ["-C", "target-feature=+crt-static"]
     - ```uboot_overlay_addr5=/lib/firmware/BB-SPIDEV1-00A0.dtbo```
 1. Create config for rusty_beagle, example config is available in rusty_beagle/conf.ron
 2. Run ```./rusty_beagle <path_to_config>``` 
+
+# How to build on Apple Silicon using Docker
+
+1. in docker directory run below
+2. docker build --platform linux/amd64 --progress=plain -t rusty_beagle .
+3. docker run --rm -v $(pwd)/output:/output rusty_beagle
+4. output of build is on the "output" directory
+
+

--- a/README.md
+++ b/README.md
@@ -38,9 +38,15 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 # How to build on Apple Silicon using Docker
 
-1. in docker directory run below
-2. docker build --platform linux/amd64 --progress=plain -t rusty_beagle .
-3. docker run --rm -v $(pwd)/output:/output rusty_beagle
-4. output of build is on the "output" directory
+1. In docker directory run commands below
+2. Docker build
+```bash
+docker build --platform linux/amd64 --progress=plain -t rusty_beagle .
+```
+3. Docker run
+```bash
+docker run --rm -v $(pwd)/output:/output rusty_beagle
+```
+4. output of build is in the "output" directory
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+# Use a base Debian image
+FROM dziedzicgrzegorz/rusty_beagle_silicon
+
+# Set up the working directory
+WORKDIR /usr/src/rust
+
+# Copy your project into the Docker container
+COPY .. .
+
+# Build the Rust project for ARM architecture
+RUN cargo build --target arm-unknown-linux-gnueabihf --release
+
+RUN cargo test
+
+#Copy the output
+CMD ["sh", "-c", "cp -r /usr/src/rust/target/arm-unknown-linux-gnueabihf/release/rusty_beagle /output"]


### PR DESCRIPTION
Building the project directly on Apple Silicon is not possible due to compatibility issues. This PR provides a workaround using Docker, ensuring developers can still build and test the project on Apple Silicon by leveraging cross-compilation techniques.